### PR TITLE
docs: update Git clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the Catch the Cat game! This is a fun and simple game where you try t
 - Clone the repository:
 
 ```bash
-git clone https://github.com/yourusername/catch-the-cat-game.git
+git clone https://github.com/LadyKerr/catch-the-cat-game.git
 ```
 - Navigate to the project directory:
 


### PR DESCRIPTION
## Summary
This PR corrects the Git clone URL in the README file. The original URL pointed to the user's own fork instead of the correct repository URL.

## Changes Made
- Updated the Git clone URL in the README to `https://github.com/LadyKerr/catch-the-cat-game.git`

## Test Plan
- Checked that the URL is now correct and points to the right repository.


## Notes
- No functional changes, just a documentation update.
